### PR TITLE
feat: add build CI for windows

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -38,7 +38,7 @@ jobs:
       - uses: messense/maturin-action@v1
         with:
           command: build
-          args: --release -o dist --find-interpreter
+          args: --release -o dist --universal2 --find-interpreter
       - name: Upload wheels
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -29,19 +29,23 @@ jobs:
           name: wheels
           path: dist
 
-  # windows:
-  #   runs-on: windows-latest
-  #   steps:
-  #     - uses: actions/checkout@v3
-  #     - uses: messense/maturin-action@v1
-  #       with:
-  #         command: build
-  #         args: --release -o dist --find-interpreter
-  #     - name: Upload wheels
-  #       uses: actions/upload-artifact@v3
-  #       with:
-  #         name: wheels
-  #         path: dist
+  windows:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: nightly-2022-12-20
+      - uses: messense/maturin-action@v1
+        with:
+          command: build
+          args: --release -o dist --find-interpreter
+      - name: Upload wheels
+        uses: actions/upload-artifact@v3
+        with:
+          name: wheels
+          path: dist
 
   macos:
     runs-on: macos-latest
@@ -52,7 +56,7 @@ jobs:
       - uses: messense/maturin-action@v1
         with:
           command: build
-          args: --release -o dist --universal2 --find-interpreter
+          args: --release -o dist
       - name: Upload wheels
         uses: actions/upload-artifact@v3
         with:
@@ -63,7 +67,7 @@ jobs:
     name: Release
     runs-on: ubuntu-latest
     if: "startsWith(github.ref, 'refs/tags/')"
-    needs: [macos, linux]
+    needs: [macos, linux, windows]
     steps:
       - uses: actions/download-artifact@v3
         with:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -33,10 +33,8 @@ jobs:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Set up Rust
-        uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: nightly-2022-12-20
+      - name: Cache
+        uses: Swatinem/rust-cache@v2
       - uses: messense/maturin-action@v1
         with:
           command: build

--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -50,10 +50,12 @@ jobs:
           pytest --cov
 
       - name: Install tzfpy and test(windows)
+        # for windows need maturin build
         if: matrix.os == 'windows-latest'
         run: |
           . venv\Scripts\activate.bat
           python -m pip install --upgrade pip
           python -m pip install -r requirements_dev.txt
-          maturin develop
+          maturin build
+          pip install target/wheels/citiespy-*.whl
           pytest --cov

--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -11,12 +11,13 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  linux:
-    runs-on: ubuntu-latest
+  Testing:
+    runs-on:  ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         python-version: ["3.9", "3.10", "3.11"]
+        os: [ubuntu-latest, windows-latest, macos-latest]
     steps:
       - uses: actions/checkout@v3
 
@@ -39,10 +40,20 @@ jobs:
         run: |
           python -m venv venv
 
-      - name: Install tzfpy and test
+      - name: Install tzfpy and test(not windows)
+        if: matrix.os != 'windows-latest'
         run: |
           source venv/bin/activate
           pip install --upgrade pip
           pip install -r requirements_dev.txt
+          maturin develop
+          pytest --cov
+
+      - name: Install tzfpy and test(windows)
+        if: matrix.os == 'windows-latest'
+        run: |
+          . venv\Scripts\activate.bat
+          python -m pip install --upgrade pip
+          python -m pip install -r requirements_dev.txt
           maturin develop
           pytest --cov

--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -57,5 +57,5 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install -r requirements_dev.txt
           maturin build
-          pip install target/wheels/citiespy-*.whl
+          pip install target/wheels/tzfpy-*.whl
           pytest --cov

--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -50,7 +50,6 @@ jobs:
           pytest --cov
 
       - name: Install tzfpy and test(windows)
-        shell: bash
         # for windows need maturin build
         if: matrix.os == 'windows-latest'
         run: |
@@ -58,5 +57,5 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install -r requirements_dev.txt
           maturin build
-          pip install target/wheels/tzfpy-*.whl
+          pip install target\wheels\tzfpy-*.whl
           pytest --cov

--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -50,6 +50,7 @@ jobs:
           pytest --cov
 
       - name: Install tzfpy and test(windows)
+        shell: bash
         # for windows need maturin build
         if: matrix.os == 'windows-latest'
         run: |

--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -50,12 +50,13 @@ jobs:
           pytest --cov
 
       - name: Install tzfpy and test(windows)
+        shell: bash
         # for windows need maturin build
         if: matrix.os == 'windows-latest'
         run: |
-          . venv\Scripts\activate.bat
+          . venv/Scripts/activate.bat
           python -m pip install --upgrade pip
           python -m pip install -r requirements_dev.txt
           maturin build
-          pip install target\wheels\tzfpy-*.whl
+          pip install target/wheels/tzfpy-*.whl
           pytest --cov

--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -54,7 +54,6 @@ jobs:
         # for windows need maturin build
         if: matrix.os == 'windows-latest'
         run: |
-          . venv/Scripts/activate.bat
           python -m pip install --upgrade pip
           python -m pip install -r requirements_dev.txt
           maturin build

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,5 +21,6 @@ crate-type = ["cdylib"]
 pyo3 = { version = "0.18.0", features = ["extension-module"] }
 lazy_static = "1.4.0"
 
+# when tzf-rs PR merged and bump another change this
 tzf-rs = { git =  "http://github.com/yihong0618/tzf-rs", rev = "fce8f4cd19ee05a8f0bd00aca3f2822a5f18ce2a"}
 # tzf-rs = "0.2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,6 @@ crate-type = ["cdylib"]
 pyo3 = { version = "0.18.0", features = ["extension-module"] }
 lazy_static = "1.4.0"
 
-# when tzf-rs PR merged and bump another change this
-tzf-rs = { git =  "http://github.com/yihong0618/tzf-rs", rev = "fce8f4cd19ee05a8f0bd00aca3f2822a5f18ce2a"}
-# tzf-rs = "0.2.0"
+# tzf-rs = { git =  "http://github.com/ringsaturn/tzf-rs", rev = "8f6873966079f8c27b6816cdfe3a1652469ebd24"}
+tzf-rs = "0.2.1"
+

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,5 +21,5 @@ crate-type = ["cdylib"]
 pyo3 = { version = "0.18.0", features = ["extension-module"] }
 lazy_static = "1.4.0"
 
-# tzf-rs = { git =  "http://github.com/ringsaturn/tzf-rs", rev = "8f6873966079f8c27b6816cdfe3a1652469ebd24"}
-tzf-rs = "0.2.0"
+tzf-rs = { git =  "http://github.com/yihong0618/tzf-rs", rev = "fce8f4cd19ee05a8f0bd00aca3f2822a5f18ce2a"}
+# tzf-rs = "0.2.0"

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,4 +1,4 @@
-citiespy==0.3.2
+citiespy==0.3.3
 maturin==0.14.8
 pytest
 pytest-benchmark


### PR DESCRIPTION
running_page use tzfpy now, and we found it does not support windows.
![image](https://user-images.githubusercontent.com/15976103/214493298-6cb8648a-fc0d-4299-96b3-31bb73ac238a.png)

pprof can not compile on windows.
1. need https://github.com/ringsaturn/tzf-rs/pull/36 merge first
2. windows test can not pass for now. because we also need citiespy support windows too then we can add windows test ci
